### PR TITLE
[feature] enable syntax '<class name>.all()' 

### DIFF
--- a/console.py
+++ b/console.py
@@ -149,6 +149,21 @@ class HBNBCommand(cmd.Cmd):
             storage.new(updated_obj)
             storage.save()
 
+    def default(self, args):
+        """Override default behaviour to allow for complex commands"""
+        arg_list = args.split(".")
+        if len(arg_list) >= 2:
+            cls_name, command, *_ = arg_list
+            if cls_name in self.__allowed_classes.keys():
+                if command[:-2] == "all":
+                    self.do_all(arg_list[0])
+                else:
+                    print("*** Unknown syntax: {}".format(args))
+            else:
+                print("*** Unknown syntax: {}".format(args))
+        else:
+            print("*** Unknown syntax: {}".format(args))
+
     def do_quit(self, line):
         """Quit command to exit the program
         """

--- a/console.py
+++ b/console.py
@@ -152,15 +152,15 @@ class HBNBCommand(cmd.Cmd):
     def default(self, args):
         """Override default behaviour to allow for complex commands"""
         arg_list = args.split(".")
-        if len(arg_list) >= 2:
-            cls_name, command, *_ = arg_list
-            if cls_name in self.__allowed_classes.keys():
-                if command[:-2] == "all":
-                    self.do_all(arg_list[0])
-                else:
-                    print("*** Unknown syntax: {}".format(args))
-            else:
-                print("*** Unknown syntax: {}".format(args))
+        if len(arg_list) < 2:
+            print("*** Unknown syntax: {}".format(args))
+            return
+        cls_name, command, *_ = arg_list
+        if cls_name not in self.__allowed_classes.keys():
+            print("*** Unknown syntax: {}".format(args))
+            return
+        if command[:-2] == "all" and command.endswith("()"):
+            self.do_all(cls_name)
         else:
             print("*** Unknown syntax: {}".format(args))
 


### PR DESCRIPTION
enable syntax `<class name>.all()` for retrieving all instances of a class